### PR TITLE
refactor: Centralise OpenAI client initialisation

### DIFF
--- a/backend/controllers/chatbotController.js
+++ b/backend/controllers/chatbotController.js
@@ -1,0 +1,25 @@
+import openai from '../lib/OpenAIClient.js';
+
+const getChatbotResponse = async (req, res) => {
+  try {
+    const { prompt } = req.body;
+
+    if (!prompt) {
+      return res.status(400).json({ message: 'Prompt is required' });
+    }
+
+    // For now, we'll just send the prompt to OpenAI
+    // In the future, this is where we'll add the logic to call the TfL API etc.
+    const completion = await openai.chat.completions.create({
+      messages: [{ role: 'system', content: 'You are Winston, a helpful and friendly chatbot for the London Underground.' }, { role: 'user', content: prompt }],
+      model: 'gpt-3.5-turbo',
+    });
+
+    res.json(completion.choices[0]);
+  } catch (error) {
+    console.error('Error calling OpenAI API:', error);
+    res.status(500).json({ message: 'Failed to get response from OpenAI', error: error.message });
+  }
+};
+
+export { getChatbotResponse };

--- a/backend/controllers/openAIController.js
+++ b/backend/controllers/openAIController.js
@@ -1,8 +1,4 @@
-import OpenAI from 'openai';
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+import openai from '../lib/OpenAIClient.js';
 
 const getOpenAIResponse = async (req, res) => {
   try {

--- a/backend/controllers/tflController.js
+++ b/backend/controllers/tflController.js
@@ -1,11 +1,7 @@
 console.log('Loading: controllers/tflController.js');
 import * as tflservice from '../services/tflservice.js';
 import googleMapsService from '../services/googleMapsService.js';
-import OpenAI from 'openai';
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+import openai from '../lib/OpenAIClient.js';
 
 //justin code
 const date = 20251016

--- a/backend/lib/OpenAIClient.js
+++ b/backend/lib/OpenAIClient.js
@@ -1,0 +1,7 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export default openai;


### PR DESCRIPTION
This pull request refactors the backend to use a single shared OpenAI API client instead of creating new instances in each controller. The new centralized client, located in backend/lib/OpenAIClient.js, replaces the duplicated setup in tflController.js, openAIController.js, and is now also used by chatbotController.js.